### PR TITLE
Add kinematic motion model as option for odometry propagation

### DIFF
--- a/vesc_ackermann/include/vesc_ackermann/vesc_to_odom.h
+++ b/vesc_ackermann/include/vesc_ackermann/vesc_to_odom.h
@@ -24,6 +24,7 @@ private:
   std::string base_frame_;
   /** State message does not report servo position, so use the command instead */
   bool use_servo_cmd_;
+  bool use_kinematic_odom_;
   // conversion gain and offset
   double speed_to_erpm_gain_, speed_to_erpm_offset_;
   double steering_to_servo_gain_, steering_to_servo_offset_;
@@ -44,6 +45,9 @@ private:
   // ROS callbacks
   void vescStateCallback(const vesc_msgs::VescStateStamped::ConstPtr& state);
   void servoCmdCallback(const std_msgs::Float64::ConstPtr& servo);
+
+  // Constant values
+  const double EPSILON_;
 };
 
 } // namespace vesc_ackermann


### PR DESCRIPTION
This PR adds the kinematic motion model as an option to compute odometry using vesc telemetry. Additionally, a new rosparam is added to toggle whether this option is to be used.